### PR TITLE
Allow to turn off logging

### DIFF
--- a/src/Cake.SqlTools/Aliases/SqlQueryAliases.cs
+++ b/src/Cake.SqlTools/Aliases/SqlQueryAliases.cs
@@ -36,22 +36,22 @@ namespace Cake.SqlTools
                 throw new ArgumentNullException("settings");
             }
 
-
+            ICakeLog log = settings.AllowLogs ? context.Log : new Logging.QuietLog();
 
             ISqlQueryRepository repository = null;
 
             switch (settings.Provider)
             {
                 case "MsSql":
-                    repository = new MsSqlQueryRepository(context.Log);
+                    repository = new MsSqlQueryRepository(log);
                     break;
 
                 case "MySql":
-                    repository = new MySqlQueryRepository(context.Log);
+                    repository = new MySqlQueryRepository(log);
                     break;
 
                 case "Npgsql":
-                    repository = new NpgsqlQueryRepository(context.Log);
+                    repository = new NpgsqlQueryRepository(log);
                     break;
             }
 
@@ -63,7 +63,7 @@ namespace Cake.SqlTools
             }
             else
             {
-                context.Log.Error("Unknown sql provider {0}", settings.Provider);
+                log.Error("Unknown sql provider {0}", settings.Provider);
                 return false;
             }
         }
@@ -88,7 +88,7 @@ namespace Cake.SqlTools
                 throw new ArgumentNullException("settings");
             }
 
-
+            ICakeLog log = settings.AllowLogs ? context.Log : new Logging.QuietLog();
 
             IFile file = context.FileSystem.GetFile(path);
 
@@ -100,7 +100,7 @@ namespace Cake.SqlTools
             }
             else
             {
-                context.Log.Error("Missing sql file {0}", path.FullPath);
+                log.Error("Missing sql file {0}", path.FullPath);
                 return false;
             }
         }

--- a/src/Cake.SqlTools/Logging/QuietLog.cs
+++ b/src/Cake.SqlTools/Logging/QuietLog.cs
@@ -1,0 +1,36 @@
+﻿using Cake.Core.Diagnostics;
+using System;
+
+namespace Cake.SqlTools.Logging
+{
+	/// <summary>
+	/// A logger implementation which does not log. Can be used to prevent null checking all the way.
+	/// </summary>
+	internal class QuietLog : ICakeLog
+	{
+		/// <summary>
+		/// Provides the method to write logs like defined in the ICakeLog interface but does not log anything.
+		/// </summary>
+		/// <param name="verbosity">The ignored verbosity of the log message.</param>
+		/// <param name="level">The ignored level of the log message</param>
+		/// <param name="format">The ignored format string for the log message</param>
+		/// <param name="args">The ignored string format arguments for the log message</param>
+		/// <remarks>
+		/// Can be used as logger to prevent the Cake tool from logging at all.
+		/// This way, the caller does not have to check for nulls.
+		/// </remarks>
+		public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
+		{
+			// log nothing
+		}
+
+		/// <summary>
+		/// Gets or sets the verbosity of the logger.
+		/// </summary>
+		public Verbosity Verbosity
+		{
+			get => Verbosity.Quiet;
+			set => throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Cake.SqlTools/Settings/SqlQuerySettings.cs
+++ b/src/Cake.SqlTools/Settings/SqlQuerySettings.cs
@@ -16,6 +16,7 @@ namespace Cake.SqlTools
         {
             this.Provider = "MsSql";
             this.ConnectionString = "";
+            this.AllowLogs = true;
         }
 		#endregion
 
@@ -33,6 +34,11 @@ namespace Cake.SqlTools
         /// Gets or sets the sql connection string to connect with
         /// </summary>
         public string ConnectionString { get; set; }
-		#endregion
+
+        /// <summary>
+        /// Gets or sets whether logs can be written or not
+        /// </summary>
+        public bool AllowLogs { get; set; }
+        #endregion
     }
 }


### PR DESCRIPTION
As written in the linked issue, I need to be able to turn off (error) logging completely. This pull request brings that feature so that callers of `ExecuteSqlQuery()` & `ExecuteSqlFile()` are able to handle errors by themselves.

Fixes #21